### PR TITLE
Google Maps API removed sensor param

### DIFF
--- a/resources/views/model/partials/form/strategies/locationpicker.blade.php
+++ b/resources/views/model/partials/form/strategies/locationpicker.blade.php
@@ -109,7 +109,7 @@
 @endpush
 
 @push('javascript-head')
-    <script src="//maps.googleapis.com/maps/api/js?key={{ $googleMapsApiKey }}&sensor=false&libraries=places"></script>
+    <script src="//maps.googleapis.com/maps/api/js?key={{ $googleMapsApiKey }}&libraries=places"></script>
 @endpush
 
 @push('javascript-end')


### PR DESCRIPTION
Param is deprecated: https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required