### PR TITLE
[Feature] Added RelationReferenceLink list strategy

### DIFF
--- a/config/cms-models.php
+++ b/config/cms-models.php
@@ -273,17 +273,18 @@ return [
 
             // Aliases for list display strategy classes
             'aliases' => [
-                Enums\ListDisplayStrategy::CHECK               => 'Check',
-                Enums\ListDisplayStrategy::CHECK_NULLABLE      => 'CheckNullable',
-                Enums\ListDisplayStrategy::DATE                => 'Date',
-                Enums\ListDisplayStrategy::TIME                => 'Time',
-                Enums\ListDisplayStrategy::DATETIME            => 'DateTime',
-                Enums\ListDisplayStrategy::STAPLER_THUMBNAIL   => 'StaplerImage',
-                Enums\ListDisplayStrategy::STAPLER_FILENAME    => 'StaplerFile',
-                Enums\ListDisplayStrategy::RELATION_COUNT      => 'RelationCount',
-                Enums\ListDisplayStrategy::RELATION_REFERENCE  => 'RelationReference',
-                Enums\ListDisplayStrategy::RELATION_COUNT_LINK => 'RelationCountChildrenLink',
-                Enums\ListDisplayStrategy::TAGS                => 'TagList',
+                Enums\ListDisplayStrategy::CHECK                   => 'Check',
+                Enums\ListDisplayStrategy::CHECK_NULLABLE          => 'CheckNullable',
+                Enums\ListDisplayStrategy::DATE                    => 'Date',
+                Enums\ListDisplayStrategy::TIME                    => 'Time',
+                Enums\ListDisplayStrategy::DATETIME                => 'DateTime',
+                Enums\ListDisplayStrategy::STAPLER_THUMBNAIL       => 'StaplerImage',
+                Enums\ListDisplayStrategy::STAPLER_FILENAME        => 'StaplerFile',
+                Enums\ListDisplayStrategy::RELATION_COUNT          => 'RelationCount',
+                Enums\ListDisplayStrategy::RELATION_REFERENCE      => 'RelationReference',
+                Enums\ListDisplayStrategy::RELATION_REFERENCE_LINK => 'RelationReferenceLink',
+                Enums\ListDisplayStrategy::RELATION_COUNT_LINK     => 'RelationCountChildrenLink',
+                Enums\ListDisplayStrategy::TAGS                    => 'TagList',
             ],
 
             // Aliases for sort strategy classes

--- a/src/Support/Enums/ListDisplayStrategy.php
+++ b/src/Support/Enums/ListDisplayStrategy.php
@@ -18,7 +18,8 @@ class ListDisplayStrategy extends Enum
 
     // Relations
 
-    const RELATION_COUNT      = 'relation-count';
-    const RELATION_REFERENCE  = 'relation-reference';
-    const RELATION_COUNT_LINK = 'relation-count-link';
+    const RELATION_COUNT          = 'relation-count';
+    const RELATION_REFERENCE      = 'relation-reference';
+    const RELATION_REFERENCE_LINK = 'relation-reference-link';
+    const RELATION_COUNT_LINK     = 'relation-count-link';
 }

--- a/src/View/ListStrategies/RelationReferenceLink.php
+++ b/src/View/ListStrategies/RelationReferenceLink.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Czim\CmsModels\View\ListStrategies;
+
+use Czim\CmsModels\Contracts\Routing\RouteHelperInterface;
+use Illuminate\Database\Eloquent\Model;
+
+class RelationReferenceLink extends RelationReference
+{
+    /**
+     * @var RouteHelperInterface
+     */
+    protected $routeHelper;
+
+    /**
+     * RelationEditLink constructor.
+     *
+     * @param RouteHelperInterface|null $routeHelper
+     */
+    public function __construct(RouteHelperInterface $routeHelper = null)
+    {
+        if (null === $routeHelper) {
+            $routeHelper = app(RouteHelperInterface::class);
+        }
+
+        $this->routeHelper = $routeHelper;
+    }
+
+    /**
+     * Returns a reference representation for a single model.
+     *
+     * @param Model $model
+     * @return string
+     */
+    protected function getReference(Model $model)
+    {
+        $reference = $this->getReferenceValue($model);
+
+        return $this->wrapWithLink($reference, $this->getLinkForReferenceModel($model));
+    }
+
+    /**
+     * Wraps given reference string with hyperlink to given url
+     *
+     * @param string $reference
+     * @param string $url
+     * @return string
+     */
+    protected function wrapWithLink($reference, $url)
+    {
+        return '<a href="' . $url . '">' . $this->wrapReference($reference) . '</a>';
+    }
+
+    /**
+     * Generates edit link for given model
+     *
+     * @param Model $model
+     * @return string
+     */
+    protected function getLinkForReferenceModel(Model $model)
+    {
+        $routeName = $this->routeHelper->getRouteNameForModelClass(
+            get_class($model),
+            true
+        );
+
+        $action = $this->determineRouteAction($model);
+
+        return route($routeName . '.' . $action, $model->getKey());
+    }
+
+    /**
+     * Determines route action for given model. We will always try for the edit action, but if
+     * the permission check fails we will fall back to the show action.
+     *
+     * @param Model $model
+     * @return string
+     */
+    protected function determineRouteAction(Model $model)
+    {
+        // Check the permissions to determine whether we're creating an
+        // edit link or a show link
+        $action = 'edit';
+        $permissionPrefix = $this->routeHelper->getPermissionPrefixForModelSlug(
+            $this->routeHelper->getRouteSlugForModelClass(get_class($model))
+        );
+
+        // Change the action to show if we don't have edit permissions
+        if ( ! cms_auth()->can($permissionPrefix . $action)) {
+            $action = 'show';
+        }
+
+        return $action;
+    }
+
+}


### PR DESCRIPTION
There is currently no strategy for displaying a link for belongsTo relations. I have created such a strategy. It will go to the edit page of referenced model by default, with a fallback to the show action if permissions are insufficient.

I have given the strategy the alias 'relation-reference-link'.