### PR TITLE
Add show_when_empty option to relationCountChildren strategy

### DIFF
--- a/src/Strategies/ListColumn/RelationCountChildrenLink.php
+++ b/src/Strategies/ListColumn/RelationCountChildrenLink.php
@@ -33,8 +33,10 @@ class RelationCountChildrenLink extends RelationCount
         $relation = $this->getActualNestedRelation($model, $source);
 
         $count = $this->getCount($relation);
+        
+        $showWhenEmpty = array_get($this->listColumnData->options(), 'show_when_empty');
 
-        if ( ! $count) {
+        if ( ! $count && ! $showWhenEmpty) {
             return '<span class="relation-count count-empty">&nbsp;</span>';
         }
 


### PR DESCRIPTION
This can be useful for linked to the related model