### PR TITLE
Prevent stretching of Paperclip image for list strategy

### DIFF
--- a/resources/views/model/partials/list/strategies/paperclip_image.blade.php
+++ b/resources/views/model/partials/list/strategies/paperclip_image.blade.php
@@ -1,5 +1,5 @@
 @if ($exists)
-    <img class="paperclip-thumbnail" src="{{ $urlThumb }}" alt="{{ $filename }}" width="{{ $width }}" height="{{ $height }}">
+    <img class="paperclip-thumbnail" src="{{ $urlThumb }}" alt="{{ $filename }}" height="{{ $height }}">
 @else
     <div class="missing-image" style="@if ($width) width: {{ $width }}px;@endif @if ($height) height: {{ $height }}px @endif"></div>
 @endif


### PR DESCRIPTION
Removing the img width attribute will prevent stretching