### PR TITLE
Checkbox ‘required’ unnecessary

### DIFF
--- a/src/ModelInformation/Data/Form/ModelFormFieldData.php
+++ b/src/ModelInformation/Data/Form/ModelFormFieldData.php
@@ -4,6 +4,7 @@ namespace Czim\CmsModels\ModelInformation\Data\Form;
 use Czim\CmsModels\Contracts\ModelInformation\Data\Form\ModelFormFieldDataInterface;
 use Czim\CmsModels\ModelInformation\Data\AbstractModelInformationDataObject;
 use Czim\CmsModels\ModelInformation\Data\ModelViewReferenceData;
+use Czim\CmsModels\Support\Enums\FormDisplayStrategy;
 
 /**
  * Class ModelFormFieldData
@@ -198,6 +199,11 @@ class ModelFormFieldData extends AbstractModelInformationDataObject implements M
     public function required()
     {
         if (null === $this->required) {
+            return false;
+        }
+
+        // A checkbox is always sent, required is unnecessary
+        if ($this->display_strategy === FormDisplayStrategy::BOOLEAN_CHECKBOX) {
             return false;
         }
 


### PR DESCRIPTION
My goal is to avoid the asterisk ( * ) for checkbox labels since not being 'checked' is still a valid input.

What are your thoughts on this?