### PR TITLE
[Fix] Relation analyzer: strip successive space characters along with newlines in raw method body evaluation.

### DIFF
--- a/src/ModelInformation/Analyzer/Processor/Steps/AnalyzeRelations.php
+++ b/src/ModelInformation/Analyzer/Processor/Steps/AnalyzeRelations.php
@@ -223,7 +223,7 @@ class AnalyzeRelations extends AbstractAnalyzerStep
      */
     protected function findRelationMethodCall($methodBody)
     {
-        $methodBody = trim(str_replace("\n", '', $methodBody));
+        $methodBody = trim(preg_replace('#\\n\\s*#', '', $methodBody));
 
         // find the last potential relation method opener and position
         $foundOpener  = null;

--- a/tests/Helpers/Models/Analyzer/TestRelation.php
+++ b/tests/Helpers/Models/Analyzer/TestRelation.php
@@ -29,6 +29,12 @@ class TestRelation extends Model
         return $this->belongsToMany(TestGlobalScope::class, 'test_belongs_to_many', 'test_relation_id', 'test_global_scope_id');
     }
 
+    public function testMultiLine()
+    {
+        return $this
+            ->hasMany(TestOrderable::class, 'test_relation_id');
+    }
+
     /**
      * Public method that is not a relation.
      *

--- a/tests/ModelInformation/Analyzer/Processor/Steps/AnalyzeRelationsTest.php
+++ b/tests/ModelInformation/Analyzer/Processor/Steps/AnalyzeRelationsTest.php
@@ -51,7 +51,7 @@ class AnalyzeRelationsTest extends AbstractStepCase
 
         static::assertInternalType('array', $info['relations']);
         static::assertEquals(
-            ['testBelongsTo', 'testHasOne', 'testHasMany', 'testBelongsToMany'],
+            ['testBelongsTo', 'testHasOne', 'testHasMany', 'testBelongsToMany', 'testMultiLine'],
             array_keys($info['relations'])
         );
 
@@ -88,6 +88,14 @@ class AnalyzeRelationsTest extends AbstractStepCase
         static::assertEquals('testBelongsToMany', $relation->name);
         static::assertEquals(TestGlobalScope::class, $relation->relatedModel);
         static::assertEquals(['test_belongs_to_many.test_relation_id', 'test_belongs_to_many.test_global_scope_id'], $relation->foreign_keys);
+
+        $relation = $info['relations']['testMultiLine'];
+        static::assertInstanceOf(ModelRelationData::class, $relation);
+        static::assertEquals(RelationType::HAS_MANY, $relation->type);
+        static::assertEquals('testMultiLine', $relation->method);
+        static::assertEquals('testMultiLine', $relation->name);
+        static::assertEquals(TestOrderable::class, $relation->relatedModel);
+        static::assertEquals(['test_orderables.test_relation_id'], $relation->foreign_keys);
     }
 
     /**


### PR DESCRIPTION
This pull request fixes a problem with analyzing relations where the initial method call to `$this` is on a new line.

Code like this is analyzed successfully:

**App\Models\User.php**

```php
public function roles()
{
    return $this->belongsToMany(\App\Models\Role::class)
        ->using(\App\Models\Pivots\UserRole::class);
}
```

whereas this code is not:

```php
public function roles()
{
    return $this
        ->belongsToMany(\App\Models\Role::class)
        ->using(\App\Models\Pivots\UserRole::class);
}
```

It threw the following exception, because of an existing relation definition `"roles"` on the CMS model for `User`:

> App\Models\User model configuration issue: 
> Issue with list column 'roles' (list.columns.roles): 
> Incomplete data for for list column key that does not match known model attribute or relation method. Requires at least 'source' and 'strategy' values.

The existing implementation of `findRelationMethodCall` replaces only newlines in the parsed method body, resulting in the following string:

```
"{    return $this        ->belongsToMany(\App\Models\Role::class)        ->using(\App\Models\Pivots\UserRole::class);}"
```

This string would then not match any of the [regular expressions returned by `relationMethodCallOpeners `][relation-method-patterns], because they do not allow whitespace. Thus the relation is not added to the list of known / valid relation methods for the model.

This commit fixes that problem by implementing the regex [as demonstrated here][regex-fail] (old) vs. [here][regex-ok] (new). The parsed body is now:

```
"{return $this->belongsToMany(\App\Models\Role::class)->using(\App\Models\Pivots\UserRole::class);}"
```

[relation-method-patterns]: https://github.com/JJWesterkamp/laravel-cms-models/blob/0e7aa92076fbdcaff9e6e01ec13deb75b9ac43c4/src/ModelInformation/Analyzer/Processor/Steps/AnalyzeRelations.php#L262

[regex-fail]: https://regex101.com/r/JTLq7v/6

[regex-ok]: https://regex101.com/r/JTLq7v/5